### PR TITLE
Check for tslint.json before deleting

### DIFF
--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -130,5 +130,5 @@ console.log(`INFO: Deleting tslint.info unnecessary file`);
 
 const TSLINT_FILEPATH = path.resolve(path.join(projectPath, 'tslint.json'));
 
-// delete file
-fs.unlinkSync(TSLINT_FILEPATH);
+// delete file (if it exists)
+if (fs.existsSync(TSLINT_FILEPATH)) { fs.unlinkSync(TSLINT_FILEPATH); }

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -126,7 +126,7 @@ fs.writeFileSync(GULPFILE_FILEPATH, gulpFileData.replace(/build.initialize\(requ
 */
 console.log('');
 console.log('ESLINT PRESET POSTINSTALL STEP 4 of 4...')
-console.log(`INFO: Deleting tslint.info unnecessary file`);
+console.log(`INFO: Deleting tslint.info unnecessary file (if present)`);
 
 const TSLINT_FILEPATH = path.resolve(path.join(projectPath, 'tslint.json'));
 


### PR DESCRIPTION
This package throws an error on install if tslint.json isn't present.
I added an if statement to check for the file before attempting to delete. Helpful if you've manually deleted it ahead of time or have already installed this package and are reinstalling or switching versions.